### PR TITLE
Firebase remote config

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion MIN_SDK
         targetSdkVersion TARGET_SDK
         versionCode 1
-        versionName "1.0"
+        versionName "2.0.0"
     }
 
     compileOptions {

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -17,10 +17,6 @@
         {
           "client_id": "145406470254-dkulh9ca3qnpbunq50pad9lt7jm38bq0.apps.googleusercontent.com",
           "client_type": 3
-        },
-        {
-          "client_id": "145406470254-dkulh9ca3qnpbunq50pad9lt7jm38bq0.apps.googleusercontent.com",
-          "client_type": 3
         }
       ],
       "api_key": [
@@ -29,15 +25,13 @@
         }
       ],
       "services": {
-        "analytics_service": {
-          "status": 1
-        },
         "appinvite_service": {
-          "status": 1,
-          "other_platform_oauth_client": []
-        },
-        "ads_service": {
-          "status": 2
+          "other_platform_oauth_client": [
+            {
+              "client_id": "145406470254-dkulh9ca3qnpbunq50pad9lt7jm38bq0.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
         }
       }
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,6 +75,7 @@
             android:label="Choose Me!"/>
         <activity android:name=".ConstraintLayoutDemoKt"
             android:label="Constraint Groups"/>
+        <activity android:name=".firebase.ABTestDemoActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/zdominguez/sdksandbox/MainActivity.kt
+++ b/app/src/main/java/com/zdominguez/sdksandbox/MainActivity.kt
@@ -12,12 +12,12 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import butterknife.OnClick
-import com.google.android.gms.tasks.OnCompleteListener
 import com.google.firebase.iid.FirebaseInstanceId
-import com.zdominguez.sdksandbox.R.string
 import com.zdominguez.sdksandbox.bottomsheet.BottomSheetShare
 import com.zdominguez.sdksandbox.databinding.ActivityMainBinding
 import com.zdominguez.sdksandbox.databinding.DialogDataBindingDemoBinding
+import com.zdominguez.sdksandbox.firebase.ABTestDemoActivity
+import com.zdominguez.sdksandbox.firebase.RemoteConfigValues
 import com.zdominguez.sdksandbox.models.AdventureTimeCharacters
 import org.parceler.Parcels
 import timber.log.Timber
@@ -43,6 +43,12 @@ class MainActivity : AppCompatActivity() {
         PreferenceManager.getDefaultSharedPreferences(this).edit().putBoolean("is_launched", false).apply()
         getSharedPreferences("${BuildConfig.APPLICATION_ID}_info", Context.MODE_PRIVATE).edit().putString("hello", "hi").apply()
         getSharedPreferences("${BuildConfig.APPLICATION_ID}_more_prefs", Context.MODE_PRIVATE).edit().putString("hello", "hi").apply()
+
+        (application as SdkSandboxApplication).remoteConfig.fetch().addOnSuccessListener {
+            val allowRemoteConfig = (application as SdkSandboxApplication).remoteConfig.getBoolean(RemoteConfigValues.REMOTE_CONFIG_ENABLED.key)
+            Timber.i("Should allow remote config? $allowRemoteConfig current version: ${BuildConfig.VERSION_NAME}")
+            binding.allowRemoteConfig.visibility = if (allowRemoteConfig) View.VISIBLE else View.GONE
+        }
     }
 
     fun goToResourceAnnotations() {
@@ -140,16 +146,12 @@ class MainActivity : AppCompatActivity() {
 
     fun logFirebaseToken() {
         FirebaseInstanceId.getInstance().instanceId
-            .addOnCompleteListener(OnCompleteListener { task ->
-                if (!task.isSuccessful) {
-                    Timber.w("getInstanceId failed")
-                    return@OnCompleteListener
-                }
+            .addOnSuccessListener { result -> Timber.d("Firebase token: ${result.token}") }
+    }
 
-                // Get new Instance ID token
-                val token = task.result?.token
-                Timber.d("Firebase token: $token")
-            })
+    fun showRemoteConfigDemo() {
+        val intent = Intent(this, ABTestDemoActivity::class.java)
+        startActivity(intent)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/app/src/main/java/com/zdominguez/sdksandbox/SdkSandboxApplication.kt
+++ b/app/src/main/java/com/zdominguez/sdksandbox/SdkSandboxApplication.kt
@@ -1,10 +1,15 @@
 package com.zdominguez.sdksandbox
 
 import android.app.Application
+import com.google.firebase.remoteconfig.FirebaseRemoteConfig
+import com.google.firebase.remoteconfig.FirebaseRemoteConfigSettings
+import com.zdominguez.sdksandbox.firebase.ABTestValues
+import com.zdominguez.sdksandbox.firebase.RemoteConfigValues
 import timber.log.Timber
 import timber.log.Timber.DebugTree
 
 class SdkSandboxApplication : Application() {
+    lateinit var remoteConfig: FirebaseRemoteConfig
 
     override fun onCreate() {
         super.onCreate()
@@ -12,5 +17,23 @@ class SdkSandboxApplication : Application() {
         if (BuildConfig.DEBUG) {
             Timber.plant(DebugTree())
         }
+
+        remoteConfig = FirebaseRemoteConfig.getInstance()
+        val configSettings = FirebaseRemoteConfigSettings.Builder()
+            .setMinimumFetchIntervalInSeconds(10)
+            .build()
+        remoteConfig.apply {
+            setConfigSettingsAsync(configSettings)
+            setDefaultsAsync(REMOTE_CONFIG_DEFAULTS + AB_TEST_DEFAULTS)
+            fetchAndActivate()
+        }
+    }
+
+    companion object {
+        private val REMOTE_CONFIG_DEFAULTS = RemoteConfigValues.values()
+            .associate { remoteConfig -> remoteConfig.key to remoteConfig.default }
+
+        private val AB_TEST_DEFAULTS = ABTestValues.values()
+            .associate { abTestValues -> abTestValues.key to abTestValues.default }
     }
 }

--- a/app/src/main/java/com/zdominguez/sdksandbox/firebase/ABTestDemoActivity.kt
+++ b/app/src/main/java/com/zdominguez/sdksandbox/firebase/ABTestDemoActivity.kt
@@ -1,0 +1,36 @@
+package com.zdominguez.sdksandbox.firebase
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.databinding.DataBindingUtil
+import com.zdominguez.sdksandbox.R
+import com.zdominguez.sdksandbox.SdkSandboxApplication
+import com.zdominguez.sdksandbox.databinding.ActivityAbDemoBinding
+import timber.log.Timber
+
+class ABTestDemoActivity: AppCompatActivity() {
+    lateinit var binding: ActivityAbDemoBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_ab_demo)
+        binding.handlers = this
+        refetch()
+    }
+
+    fun refetch() {
+        val remoteConfig = (application as SdkSandboxApplication).remoteConfig
+
+        remoteConfig.fetchAndActivate().addOnSuccessListener {
+            // source: 0 - not found, 1 - local defaults, 2 - activated values
+
+            val buttonColourValue = remoteConfig.getValue(ABTestValues.BUTTON_COLOUR.key)
+            Timber.i("Returned button colour value? ${buttonColourValue.asString()} source: ${buttonColourValue.source}")
+            binding.fetchedValue.text = "Fetched value from config = ${buttonColourValue.asString()}"
+
+            val buttonCountValue = remoteConfig.getValue(ABTestValues.BUTTON_COUNT.key)
+            Timber.i("Returned button count value? ${buttonCountValue.asLong()} source: ${buttonCountValue.source}")
+            binding.buttonCount.text = "Fetched value from config for button count = ${buttonCountValue.asLong()}"
+        }
+    }
+}

--- a/app/src/main/java/com/zdominguez/sdksandbox/firebase/ABTestValues.kt
+++ b/app/src/main/java/com/zdominguez/sdksandbox/firebase/ABTestValues.kt
@@ -1,0 +1,6 @@
+package com.zdominguez.sdksandbox.firebase
+
+enum class ABTestValues(val key: String, val default: Any) {
+    BUTTON_COLOUR("ab_button_colour", "red"),
+    BUTTON_COUNT("ab_button_count", 0)
+}

--- a/app/src/main/java/com/zdominguez/sdksandbox/firebase/RemoteConfigValues.kt
+++ b/app/src/main/java/com/zdominguez/sdksandbox/firebase/RemoteConfigValues.kt
@@ -1,0 +1,5 @@
+package com.zdominguez.sdksandbox.firebase
+
+enum class RemoteConfigValues(val key: String, val default: Boolean) {
+    REMOTE_CONFIG_ENABLED("remote_config_enabled", false)
+}

--- a/app/src/main/res/layout/activity_ab_demo.xml
+++ b/app/src/main/res/layout/activity_ab_demo.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <data>
+        <variable
+            name="handlers"
+            type="com.zdominguez.sdksandbox.firebase.ABTestDemoActivity" />
+
+    </data>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/fetched_value"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="16dp" />
+
+        <TextView
+            android:id="@+id/button_count"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="16dp" />
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Re-fetch values"
+            android:onClick="@{() -> handlers.refetch()}"/>
+
+    </LinearLayout>
+</layout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -83,6 +83,12 @@
             android:onClick="@{() -> handlers.logFirebaseToken()}"
             android:text="Log Firebase Token"/>
 
+        <Button android:id="@+id/allow_remote_config"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:onClick="@{() -> handlers.showRemoteConfigDemo()}"
+            android:text="Remote Config demo"/>
+
         <EditText
             android:id="@+id/first_name"
             android:layout_width="match_parent"


### PR DESCRIPTION
Firebase Remote Config + A/B Test demo.

If app version is EQUAL OR ABOVE `2.0.0`, the app would show an additional button in the main screen with text "Remote Config Demo"; otherwise, the button is not visible.

Remote config conditions:
![Screen Shot 2020-03-05 at 19 37 21](https://user-images.githubusercontent.com/410969/75963930-78481600-5f1a-11ea-94ae-e57dbef3baaa.png)

Remote config parameters:
![Screen Shot 2020-03-05 at 19 37 05](https://user-images.githubusercontent.com/410969/75963946-7d0cca00-5f1a-11ea-925f-7658a8b78c58.png)

The A/B test is set up to have two different kinds of values -- a string and a long -- to illustrate how different types can be safely retrieved from Firebase.
![Screen Shot 2020-03-05 at 19 51 46](https://user-images.githubusercontent.com/410969/75964205-e5f44200-5f1a-11ea-94ed-565b6b44287c.png)
